### PR TITLE
Revert "Bump gulp-terser from 1.2.0 to 1.2.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 		"gulp-replace": "1.0.0",
 		"gulp-sourcemaps": "2.6.5",
 		"gulp-stylus": "2.7.0",
-		"gulp-terser": "1.2.1",
+		"gulp-terser": "1.2.0",
 		"gulp-tslint": "8.1.4",
 		"gulp-typescript": "5.0.1",
 		"hard-source-webpack-plugin": "0.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4618,14 +4618,14 @@ gulp-stylus@2.7.0:
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-terser@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/gulp-terser/-/gulp-terser-1.2.1.tgz#d5b0ee7ebb1107c1a7bb92449629b07a1951b896"
-  integrity sha512-wFWfO6hqPwHbzyulA67ZiC2mFXQO4bPno82cvL/V6qZsFXvYxKeeFuLSNsv+i/POhyfNJLkDrcye4rRxkvJUAA==
+gulp-terser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gulp-terser/-/gulp-terser-1.2.0.tgz#41df2a1d0257d011ba8b05efb2568432ecd0495b"
+  integrity sha512-lf+jE2DALg2w32p0HRiYMlFYRYelKZPNunHp2pZccCYrrdCLOs0ItbZcN63yr2pbz116IyhUG9mD/QbtRO1FKA==
   dependencies:
     plugin-error "^1.0.1"
-    terser ">=4"
-    through2 "^4.0.2"
+    terser "^4.0.0"
+    through2 "^3.0.1"
     vinyl-sourcemaps-apply "^0.2.1"
 
 gulp-tslint@8.1.4:
@@ -8596,7 +8596,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -10055,7 +10055,16 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@>=4, terser@^4.1.2, terser@^4.8.0:
+terser@^4.0.0, terser@^4.1.2:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
+  integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -10120,13 +10129,6 @@ through2@3.0.1, through2@^3.0.0, through2@^3.0.1:
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
   dependencies:
     readable-stream "2 || 3"
-
-through2@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
-  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
-  dependencies:
-    readable-stream "3"
 
 through@2, through@^2.3.6, through@~2.3.8:
   version "2.3.8"


### PR DESCRIPTION
Reverts mei23/misskey-v11#322
`terser`バージョンが`4.x`に固定できずに`5.0.0`になるとエラーになる