### PR TITLE
DockerイメージをDebianベースに

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,30 @@
-FROM node:16.17.1-alpine3.15 AS base
+FROM node:16.17.1-bullseye AS builder
 
 ENV NODE_ENV=production
-
 WORKDIR /misskey
 
-FROM base AS builder
-
-RUN apk add --no-cache \
-    autoconf \
-    automake \
-    file \
-    g++ \
-    gcc \
-    libc-dev \
-    libtool \
-    make \
-    nasm \
-    pkgconfig \
-    python3 \
-    zlib-dev
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential
 
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./
 RUN yarn build
 
-FROM base AS runner
 
-RUN apk add --no-cache \
-    ffmpeg \
-    tini
+FROM node:16.17.1-bullseye-slim AS runner
 
-ENTRYPOINT ["/sbin/tini", "--"]
+WORKDIR /misskey
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg tini \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /misskey/node_modules ./node_modules
 COPY --from=builder /misskey/built ./built
 COPY . ./
 
+ENV NODE_ENV=production
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["npm", "run", "migrateandstart"]


### PR DESCRIPTION
## Summary
他のバージョン / fork / 開発環境 など、ほとんどDebianベースため
保守の関係上DockerイメージをDebianベースに変更。