### PR TITLE
アプリ側でDNSキャッシュをしないように

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
 		"blurhash": "1.1.5",
 		"bootstrap-vue": "2.22.0",
 		"bull": "4.9.0",
-		"cacheable-lookup": "6.0.4",
 		"cafy": "15.2.1",
 		"cbor": "8.1.0",
 		"chalk": "4.1.2",

--- a/src/misc/dns.ts
+++ b/src/misc/dns.ts
@@ -1,0 +1,33 @@
+import * as dns from 'dns';
+
+type LookupOneCallback = (err: Error | null, address?: string, family?: number) => void;
+
+export function lookup(hostname: string, options: { family?: number, hints?: number }, callback: LookupOneCallback) {
+	if (options.family === 4) {
+		dns.promises.resolve4(hostname).then(addresses => {
+			callback(null, pickRandom(addresses), 4);
+		}).catch(err => {
+			callback(err);
+		});
+	} else if (options.family === 6) {
+		dns.promises.resolve6(hostname).then(addresses => {
+			callback(null, pickRandom(addresses), 6);
+		}).catch(err => {
+			callback(err);
+		});
+	} else {
+		dns.promises.resolve4(hostname).then(addresses => {
+			callback(null, pickRandom(addresses), 4);
+		}).catch(err4 => {
+			dns.promises.resolve6(hostname).then(addresses => {
+				callback(null, pickRandom(addresses), 6);
+			}).catch(err6 => {
+				callback(err6);
+			});
+		});
+	}
+}
+
+function pickRandom(s: string[]) {
+	return s[Math.floor(Math.random() * s.length)];
+}

--- a/src/misc/fetch.ts
+++ b/src/misc/fetch.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import CacheableLookup from 'cacheable-lookup';
+import { lookup } from './dns';
 import fetch from 'node-fetch';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import config from '../config';
@@ -75,11 +75,6 @@ function objectAssignWithLcKey(a: Record<string, string>, b: Record<string, stri
 }
 
 //#region Agent
-const cache = new CacheableLookup({
-	maxTtl: 3600,	// 1hours
-	errorTtl: 30,	// 30secs
-	lookup: false,	// nativeのdns.lookupにfallbackしない
-});
 
 /**
  * Get http non-proxy agent
@@ -87,7 +82,7 @@ const cache = new CacheableLookup({
 const _http = new http.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 30 * 1000,
-	lookup: cache.lookup,	// DefinitelyTyped issues
+	lookup: lookup,
 } as http.AgentOptions);
 
 /**
@@ -96,7 +91,7 @@ const _http = new http.Agent({
 const _https = new https.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 30 * 1000,
-	lookup: cache.lookup,
+	lookup: lookup,
 } as https.AgentOptions);
 
 const maxSockets = Math.max(256, config.deliverJobConcurrency || 128);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,11 +2012,6 @@ cache-content-type@^1.0.0:
     mime-types "^2.1.18"
     ylru "^1.2.0"
 
-cacheable-lookup@6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz#65c0e51721bb7f9f2cb513aed6da4a1b93ad7dc8"
-  integrity sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==
-
 cacheable-lookup@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"


### PR DESCRIPTION
## Summary
アプリ側でのDNSキャッシュをしているが、DNSキャッシュはsystemd-resolvedが使われるディストリならばデフォルトで有効で不要なのでしないように。

ただし、デフォルトの `dns.lookup` (OSシステムコール) はパフォーマンスの問題があるため、`dns.resolve*()` (DNSリクエスト) でのラッパーを作成する。
https://nodejs.org/api/dns.html#implementation-considerations

また、DNS名前解決でIPv4を優先するように。