### PR TITLE
Adjust UV_THREADPOOL_SIZE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 Error.stackTraceLimit = Infinity;
 
 require('events').EventEmitter.defaultMaxListeners = 128;
-process.env.UV_THREADPOOL_SIZE = `${Math.min(Math.max(4, require('os').cpus().length), 1024)}`;
+process.env.UV_THREADPOOL_SIZE = process.env.UV_THREADPOOL_SIZE || `${Math.min(Math.max(4, require('os').cpus().length), 1024)}`;
 
 import boot from './boot';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 Error.stackTraceLimit = Infinity;
 
 require('events').EventEmitter.defaultMaxListeners = 128;
+process.env.UV_THREADPOOL_SIZE = `${Math.min(Math.max(4, require('os').cpus().length), 1024)}`;
 
 import boot from './boot';
 


### PR DESCRIPTION
## Summary
libuvのスレッドプールサイズをデフォルトの4から利用可能な論理CPUのサイズにまで自動的に増やすように。
論理CPUが5以上ある環境において、ファイル I/O, 名前解決のうちのProxyの名前解決, 暗号論的擬似乱数生成器, 秘密鍵生成 あたりのパフォーマンス または お互いのブロック が改善する可能性がある。
https://nodejs.org/api/cli.html#uv_threadpool_sizesize

環境変数 `UV_THREADPOOL_SIZE` が指定されていた場合はそちらを優先する。