### PR TITLE
enhance: Embedded all attachment, renotes and discussion history into rss feed content & improve title

### DIFF
--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -1,26 +1,36 @@
 import { Feed } from 'feed';
 import config from '../../config';
 import { User } from '../../models/entities/user';
-import { Notes, DriveFiles, UserProfiles } from '../../models';
-import { In } from 'typeorm';
+import { Notes, DriveFiles, UserProfiles, Users } from '../../models';
+import { In, IsNull } from 'typeorm';
 import { ensure } from '../../prelude/ensure';
 
-export default async function(user: User) {
+export default async function(user: User, threadDepth = 5, history = 20, noteintitle = false, renotes = true, replies = true) {
 	const author = {
 		link: `${config.url}/@${user.username}`,
+		email: `${user.username}@${config.host}`,
 		name: user.name || user.username
 	};
 
 	const profile = await UserProfiles.findOne(user.id).then(ensure);
 
+	const searchCriteria = {
+		userId: user.id,
+		visibility: In(['public', 'home']),
+	};
+
+	if (!renotes) {
+		searchCriteria.renoteId = IsNull();
+	}
+
+	if (!replies) {
+		searchCriteria.replyId = IsNull();
+	}
+
 	const notes = await Notes.find({
-		where: {
-			userId: user.id,
-			renoteId: null,
-			visibility: In(['public', 'home'])
-		},
+		where: searchCriteria,
 		order: { createdAt: -1 },
-		take: 20
+		take: history,
 	});
 
 	const feed = new Feed({
@@ -36,23 +46,81 @@ export default async function(user: User) {
 			atom: `${author.link}.atom`,
 		},
 		author,
-		copyright: user.name || user.username
+		copyright: user.name || user.username,
 	});
 
 	for (const note of notes) {
-		const files = note.fileIds.length > 0 ? await DriveFiles.find({
-			id: In(note.fileIds)
-		}) : [];
-		const file = files.find(file => file.type.startsWith('image/'));
+		let contentStr = await noteToString(note, true);
+		let next = note.renoteId ? note.renoteId : note.replyId;
+		let depth = threadDepth;
+		while (depth > 0 && next) {
+			const finding = await findById(next);
+			contentStr += finding.text;
+			next = finding.next;
+			depth -= 1;
+		}
+
+		let title = `${author.name} `;
+		if (note.renoteId) {
+			title += 'renotes';
+		} else if (note.replyId) {
+			title += 'replies';
+		} else {
+			title += 'says';
+		}
+		if (noteintitle) {
+			const content = note.cw ?? note.text;
+			if (content) {
+				title += `: ${content}`;
+			} else {
+				title += 'something';
+			}
+		}
 
 		feed.addItem({
-			title: `New note by ${author.name}`,
+			title: title.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '').substring(0,100),
 			link: `${config.url}/notes/${note.id}`,
 			date: note.createdAt,
-			description: note.cw || undefined,
-			content: note.text || undefined,
-			image: file ? DriveFiles.getPublicUrl(file) || undefined : undefined
+			description: note.cw ? note.cw.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '') : undefined,
+			content: contentStr.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
 		});
+	}
+
+	async function noteToString(note, isTheNote = false) {
+		const author = isTheNote ? null : await Users.findOne({ id: note.userId });
+		let outstr = author ? `${author.name}(@${author.username}@${author.host ? author.host : config.host}) ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}: <br>` : '';
+		const files = note.fileIds.length > 0 ? await DriveFiles.find({
+			id: In(note.fileIds),
+		}) : [];
+		let fileEle = '';
+		for (const file of files) {
+			if (file.type.startsWith('image/')) {
+				fileEle += ` <br><img src="${DriveFiles.getPublicUrl(file)}">`;
+			} else if (file.type.startsWith('audio/')) {
+				fileEle += ` <br><audio controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
+			} else if (file.type.startsWith('video/')) {
+				fileEle += ` <br><video controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
+			} else {
+				fileEle += ` <br><a href="${DriveFiles.getPublicUrl(file)}" download="${file.name}">${file.name}</a>`;
+			}
+		}
+		outstr += `${note.cw ? note.cw + '<br>' : ''}${note.text || ''}${fileEle}`;
+		if (isTheNote) {
+			outstr += ` <span class="${(note.renoteId ? 'renote_note' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') !== -1 ? 'with_img' : 'without_img')}"></span>`;
+		}
+		return outstr;
+	}
+
+	async function findById(id) {
+		let text = '';
+		let next = null;
+		const findings = await Notes.findOne({ id: id, visibility: In(['public', 'home']) });
+		if (findings) {
+			text += `<hr>`;
+			text += await noteToString(findings);
+			next = findings.renoteId ? findings.renoteId : findings.replyId;
+		}
+		return { text, next };
 	}
 
 	return feed;


### PR DESCRIPTION
## Summary

The feed npm module dose not support multiple files, and enclosure format may not parse correct by apps, so that embedding all files into content. Also the email field is required by some app, so add a dummy one, could improved by use user email if have one.

The feed also can track back x posts for reply and renote, by using query string e.g. https://xxx/@xxx.atom?history=5 will include 5 most recent notes in the thread

query example: https://xxx.xxx/@xxx.atom?thread=3&history=5&noteintitle&norenotes&noreplies

thread: how deep a thread can go (reply history)
history: how many notes totaly
noteintitle: put note content in title
norenotes: no renotes in feed
noreplies: no noreplies in feed

originally for v11 then move to v12 now back to v11 https://github.com/misskey-dev/misskey/pull/8834
