### PR TITLE
Tune client IP detection

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -135,3 +135,7 @@ autoAdmin: true
 
 # Upload or download file size limits (bytes)
 #maxFileSize: 262144000
+
+# リバースプロキシからのreal IP addressを取得するためのヘッダー
+# X-Forwarded-For, CF-Connecting-IP など
+proxyIpHeader: 'X-Forwarded-For'

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -63,6 +63,8 @@ export type Source = {
 	mediaProxy?: string;
 
 	signToActivityPubGet?: boolean;
+
+	proxyIpHeader?: string;
 };
 
 /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,7 +28,10 @@ export const serverLogger = new Logger('server', 'gray', false);
 
 // Init app
 const app = new Koa();
+
 app.proxy = true;
+(app as any).maxIpsCount = 1;
+(app as any).proxyIpHeader = config.proxyIpHeader ?? 'X-Forwarded-For';
 
 if (!['production', 'test'].includes(process.env.NODE_ENV || '')) {
 	// Logger


### PR DESCRIPTION
## Summary
X-Forwarded-For からクライアントIPアドレスを取得するときに、1つ分しか再帰しないように。
取得元ヘッダを変更できるように。