### PR TITLE
Improve URL check

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 		"stringz": "2.1.0",
 		"stylus": "0.59.0",
 		"stylus-loader": "7.1.0",
-		"summaly": "2.7.0",
+		"summaly": "mei23/summaly#3.6.0",
 		"syslog-pro": "1.0.0",
 		"systeminformation": "5.17.12",
 		"syuilo-password-strength": "0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ specifiers:
   stringz: 2.1.0
   stylus: 0.59.0
   stylus-loader: 7.1.0
-  summaly: 2.7.0
+  summaly: mei23/summaly#3.6.0
   syslog-pro: 1.0.0
   systeminformation: 5.17.12
   syuilo-password-strength: 0.0.1
@@ -349,7 +349,7 @@ dependencies:
   stringz: 2.1.0
   stylus: 0.59.0
   stylus-loader: 7.1.0_v3eweur3wq6qa32zxw4vknjbri
-  summaly: 2.7.0
+  summaly: github.com/mei23/summaly/206c16cec38f9553990bf09cbbb0c89244ae76a3
   syslog-pro: 1.0.0
   systeminformation: 5.17.12
   syuilo-password-strength: 0.0.1
@@ -454,6 +454,18 @@ packages:
 
   /@adobe/css-tools/4.0.2:
     resolution: {integrity: sha512-Fx6tYjk2wKUgLi8uMANZr8GNZx05u44ArIJldn9VxLvolzlJVgHbTUCbwhMd6bcYky178+WUSxPHO3DAtGLWpw==}
+    dev: false
+
+  /@apideck/better-ajv-errors/0.3.6_ajv@8.12.0:
+    resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      ajv: '>=8'
+    dependencies:
+      ajv: 8.12.0
+      json-schema: 0.4.0
+      jsonpointer: 5.0.1
+      leven: 3.1.0
     dev: false
 
   /@babel/code-frame/7.18.6:
@@ -848,6 +860,10 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: true
+
+  /@sinclair/typebox/0.25.24:
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+    dev: false
 
   /@sindresorhus/is/4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -1894,6 +1910,15 @@ packages:
       indent-string: 4.0.0
     dev: false
 
+  /ajv-formats/2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.12.0
+    dev: false
+
   /ajv-keywords/3.5.2_ajv@6.12.6:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -1908,6 +1933,15 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  /ajv/8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: false
 
   /animejs/3.2.1:
     resolution: {integrity: sha512-sWno3ugFryK5nhiDm/2BKeFCpZv7vzerWUcUPyAZLDhMek3+S/p418ldZJbJXo5ZUOpfm2kP2XRO4NJcULMy9A==}
@@ -3379,6 +3413,10 @@ packages:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
     dev: false
 
+  /cookie-es/1.0.0:
+    resolution: {integrity: sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ==}
+    dev: false
+
   /cookies/0.8.0:
     resolution: {integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==}
     engines: {node: '>= 0.8'}
@@ -3715,18 +3753,6 @@ packages:
       ms: 2.1.3
     dev: false
 
-  /debug/4.3.3:
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: false
-
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -3844,6 +3870,10 @@ packages:
       isobject: 3.0.1
     dev: false
 
+  /defu/6.1.2:
+    resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
+    dev: false
+
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3869,6 +3899,10 @@ packages:
   /depd/2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+    dev: false
+
+  /destr/1.2.2:
+    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
     dev: false
 
   /destroy/1.2.0:
@@ -4798,7 +4832,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -5022,23 +5056,6 @@ packages:
       get-intrinsic: 1.1.3
     dev: false
 
-  /got/11.8.5:
-    resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
-    engines: {node: '>=10.19.0'}
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.0
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.2
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
-    dev: false
-
   /got/11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
@@ -5193,6 +5210,28 @@ packages:
       glogg: 1.0.2
     dev: false
 
+  /h3-typebox/0.6.0:
+    resolution: {integrity: sha512-GFQwo043+8bQA4e0tHcc5DWwgS9r5wiGd4pEzOKdcTjRhAnJz/Ryfz1bjkRVbmqZVXaDuvUrPWWBxTVrfpfSzg==}
+    dependencies:
+      '@apideck/better-ajv-errors': 0.3.6_ajv@8.12.0
+      '@sinclair/typebox': 0.25.24
+      ajv: 8.12.0
+      ajv-formats: 2.1.1
+      h3: 1.6.5
+    dev: false
+
+  /h3/1.6.5:
+    resolution: {integrity: sha512-A0r2LCDzeavSfcAbJpMwHXLcSN0H3FpEZtYigbz4IYun0fOE8r6vy3galwubAnmc6gXVob4261zXQsu3sZayzg==}
+    dependencies:
+      cookie-es: 1.0.0
+      defu: 6.1.2
+      destr: 1.2.2
+      iron-webcrypto: 0.7.0
+      radix3: 1.0.1
+      ufo: 1.1.2
+      uncrypto: 0.1.3
+    dev: false
+
   /has-ansi/2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
@@ -5316,8 +5355,8 @@ packages:
       whatwg-encoding: 2.0.0
     dev: false
 
-  /html-entities/2.3.2:
-    resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
+  /html-entities/2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
     dev: false
 
   /html-minifier/4.0.0:
@@ -5599,6 +5638,10 @@ packages:
   /ipaddr.js/2.0.1:
     resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
     engines: {node: '>= 10'}
+    dev: false
+
+  /iron-webcrypto/0.7.0:
+    resolution: {integrity: sha512-WkX32iTcwd79ZsWRPP5wq1Jq6XXfPwO783ZiUBY8uMw4/AByx5WvBmxvYGnpVt6AOVJ0F41Qo420r8lIneT9Wg==}
     dev: false
 
   /is-absolute/1.0.0:
@@ -6116,7 +6159,6 @@ packages:
 
   /json-schema-traverse/1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: true
 
   /json-schema/0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -6165,6 +6207,11 @@ packages:
     transitivePeerDependencies:
       - domexception
       - web-streams-polyfill
+    dev: false
+
+  /jsonpointer/5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /jsprim/2.0.2:
@@ -6484,6 +6531,11 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       flush-write-stream: 1.1.1
+    dev: false
+
+  /leven/3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
     dev: false
 
   /levn/0.3.0:
@@ -8175,15 +8227,6 @@ packages:
       js-beautify: 1.14.7
     dev: false
 
-  /private-ip/2.3.3:
-    resolution: {integrity: sha512-5zyFfekIVUOTVbL92hc8LJOtE/gyGHeREHkJ2yTyByP8Q2YZVoBqLg3EfYLeF0oVvGqtaEX2t2Qovja0/gStXw==}
-    dependencies:
-      ip-regex: 4.3.0
-      ipaddr.js: 2.0.1
-      is-ip: 3.1.0
-      netmask: 2.0.2
-    dev: false
-
   /private-ip/2.3.4:
     resolution: {integrity: sha512-ts/YFVwfBeLq61f9+KsOhXW6RH0wvY0gU50R6QZYzgFhggyyLK6WDFeYdjfi/HMnBm2hecLvsR3PB3JcRxDk+A==}
     dependencies:
@@ -8431,6 +8474,10 @@ packages:
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /radix3/1.0.1:
+    resolution: {integrity: sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==}
     dev: false
 
   /random-seed/0.3.0:
@@ -8710,7 +8757,6 @@ packages:
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /require-main-filename/1.0.1:
     resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
@@ -9383,24 +9429,6 @@ packages:
       - supports-color
     dev: false
 
-  /summaly/2.7.0:
-    resolution: {integrity: sha512-pEz9LL8Gp0oPIQfn6TrnBCcv/HkFE14hxhH3W6LPGdopXlPXjRcMlDMJaO+VupUNMOGaMjCsjq7+0rWnu8sp7w==}
-    dependencies:
-      cheerio: 1.0.0-rc.12
-      debug: 4.3.3
-      escape-regexp: 0.0.1
-      got: 11.8.5
-      html-entities: 2.3.2
-      iconv-lite: 0.6.3
-      jschardet: 3.0.0
-      koa: 2.13.4
-      private-ip: 2.3.3
-      require-all: 3.0.0
-      trace-redirect: 1.0.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /supports-color/2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
     engines: {node: '>=0.8.0'}
@@ -9811,10 +9839,6 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /trace-redirect/1.0.6:
-    resolution: {integrity: sha512-UUfa1DjjU5flcjMdaFIiIEGDTyu2y/IiMjOX4uGXa7meKBS4vD4f2Uy/tken9Qkd4Jsm4sRsfZcIIPqrRVF3Mg==}
-    dev: false
-
   /ts-loader/9.4.2_w6zjx75bct6vaixfrpcwixys6m:
     resolution: {integrity: sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==}
     engines: {node: '>=12.0.0'}
@@ -10027,6 +10051,16 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  /typescript/5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+    dev: false
+
+  /ufo/1.1.2:
+    resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
+    dev: false
+
   /uglify-js/3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -10050,6 +10084,10 @@ packages:
   /unc-path-regex/0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /uncrypto/0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
     dev: false
 
   /undertaker-registry/1.0.1:
@@ -11051,6 +11089,24 @@ packages:
     resolution: {tarball: https://codeload.github.com/mei23/memoji/tar.gz/2ac2e9ba5b82b017373dda6ccf745dc315aa1592}
     name: memoji
     version: 15.0.1
+    dev: false
+
+  github.com/mei23/summaly/206c16cec38f9553990bf09cbbb0c89244ae76a3:
+    resolution: {tarball: https://codeload.github.com/mei23/summaly/tar.gz/206c16cec38f9553990bf09cbbb0c89244ae76a3}
+    name: summaly
+    version: 3.6.0
+    dependencies:
+      cheerio: 1.0.0-rc.12
+      escape-regexp: 0.0.1
+      got: 11.8.6
+      h3: 1.6.5
+      h3-typebox: 0.6.0
+      html-entities: 2.3.3
+      iconv-lite: 0.6.3
+      js-yaml: 4.1.0
+      jschardet: 3.0.0
+      private-ip: 2.3.4
+      typescript: 5.0.4
     dev: false
 
   github.com/mei23/twemoji-parser/75831bfddb415cefc1e89ac5232e883daf91a624:

--- a/src/misc/check-allowed-url.ts
+++ b/src/misc/check-allowed-url.ts
@@ -1,0 +1,40 @@
+const PrivateIp = require('private-ip');
+
+export function checkAllowedUrl(url: string | URL | undefined): boolean {
+	if (process.env.NODE_ENV !== 'production') return true;
+
+	try {
+		if (url == null) return false;
+
+		const u = typeof url === 'string' ? new URL(url) : url;
+
+		// procotol
+		if (!u.protocol.match(/^https?:$/)) {
+			return false;
+		}
+
+		// non dot host
+		if (!u.hostname.includes('.')) {
+			return false;
+		}
+
+		// port
+		if (u.port !== '' && !['80', '443'].includes(u.port)) {
+			return false;
+		}
+
+		// private address
+		if (PrivateIp(u.hostname)) {
+			return false;
+		}
+
+		// has auth
+		if (u.username || u.password) {
+			return false;
+		}
+
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/test/check-allowed-url.ts
+++ b/test/check-allowed-url.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import { checkAllowedUrl } from '../src/misc/check-allowed-url';
+
+describe('checkAllowedUrl', () => {
+	before(() => {
+		process.env.NODE_ENV = 'production';
+	});
+
+	after(() => {
+		process.env.NODE_ENV = 'test';
+	});
+
+	it('Allow https', () => {
+		assert.strictEqual(checkAllowedUrl('https://example.com/'), true);
+	});
+
+	it('Allow http', () => {
+		assert.strictEqual(checkAllowedUrl('https://example.com/'), true);
+	});
+
+	it('Deny unix', () => {
+		assert.strictEqual(checkAllowedUrl('unix:/var/run/docker.sock:/containers/json'), false);
+	});
+
+	it('Deny unix host', () => {
+		assert.strictEqual(checkAllowedUrl('http://unix:/var/run/docker.sock:/containers/json'), false);
+	});
+
+	it('Deny http non 80', () => {
+		assert.strictEqual(checkAllowedUrl('http://example.com:3000/'), false);
+	});
+
+	it('Deny https non 443', () => {
+		assert.strictEqual(checkAllowedUrl('https://example.com:3000/'), false);
+	});
+
+	it('Allow https:443', () => {
+		assert.strictEqual(checkAllowedUrl('https://example.com:443/'), true);
+	});
+
+	it('Deny non dot host', () => {
+		assert.strictEqual(checkAllowedUrl('http://foo/'), false);
+	});
+
+	it('Deny private IP address', () => {
+		assert.strictEqual(checkAllowedUrl('http://127.0.0.1/'), false);
+		assert.strictEqual(checkAllowedUrl('http://192.168.0.254/'), false);
+		assert.strictEqual(checkAllowedUrl('http://169.254.169.254/'), false);
+		assert.strictEqual(checkAllowedUrl('http://::1/'), false);
+		assert.strictEqual(checkAllowedUrl('http://10.0xFF.0377/'), false);
+	});
+
+	it('Allow global IP address', () => {
+		assert.strictEqual(checkAllowedUrl('http://192.0.2.1/'), false);
+	});
+
+	it('Deny with auth user', () => {
+		assert.strictEqual(checkAllowedUrl('http://user@example.com/'), false);
+		assert.strictEqual(checkAllowedUrl('http://user:@example.com/'), false);
+	});
+
+	it('Deny with auth user:pass', () => {
+		assert.strictEqual(checkAllowedUrl('http://user:pass@example.com/'), false);
+	});
+
+	it('Deny with auth pass', () => {
+		assert.strictEqual(checkAllowedUrl('http://:pass@example.com/'), false);
+	});
+});


### PR DESCRIPTION
## Summary
ファイルダウンロードとURLプレビューにて以下のURLへのリクエストは拒否するように

- httpでもhttpsでもないプロトコル
- ドットなしホスト
- 80でも443でもないポート
- プライベートアドレス
- 認証URL

syuilo/summaly (npmのsummaly) は保守されないので mei23/summaly に変更
(現行は misskey-dev/summaly だけど、ESMだったり遅かったりするので使わない)

ファイルダウンロードとURLプレビュー以外は #2379 をやったタイミングで対応したい
