### PR TITLE
indexable

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -757,6 +757,7 @@ common/views/components/profile-editor.vue:
   is-locked: "Follower requests require approval"
   careful-bot: "Follower requests from bots require approval"
   auto-accept-followed: "Automatically approve follows from the people you follow"
+  isIndexable: "Allow post search"
   advanced: "Other"
   privacy: "Privacy"
   save: "Save"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -816,6 +816,7 @@ common/views/components/profile-editor.vue:
   is-locked: "フォローを承認制にする"
   careful-bot: "Botからのフォローだけ承認制にする"
   auto-accept-followed: "フォローしているユーザーからのフォローを自動承認する"
+  isIndexable: "投稿検索を許可する"
   advanced: "その他"
   privacy: "プライバシー"
   save: "保存"

--- a/migration/1695595746908-isIndexable.ts
+++ b/migration/1695595746908-isIndexable.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class isIndexable1695595746908 implements MigrationInterface {
+    name = 'isIndexable1695595746908'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "isIndexable" boolean NOT NULL DEFAULT true`);
+        await queryRunner.query(`COMMENT ON COLUMN "user"."isIndexable" IS 'Search indexable.'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`COMMENT ON COLUMN "user"."isIndexable" IS 'Search indexable.'`);
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isIndexable"`);
+    }
+
+}

--- a/src/client/app/common/views/components/settings/profile.vue
+++ b/src/client/app/common/views/components/settings/profile.vue
@@ -92,6 +92,7 @@
 			<ui-switch v-model="isLocked" @change="save(false)">{{ $t('is-locked') }}</ui-switch>
 			<ui-switch v-model="carefulBot" :disabled="isLocked" @change="save(false)">{{ $t('careful-bot') }}</ui-switch>
 			<ui-switch v-model="autoAcceptFollowed" :disabled="!isLocked && !carefulBot" @change="save(false)">{{ $t('auto-accept-followed') }}</ui-switch>
+			<ui-switch v-model="isIndexable" @change="save(false)">{{ $t('isIndexable') }}</ui-switch>
 		</div>
 	</section>
 
@@ -176,6 +177,7 @@ export default Vue.extend({
 			isLocked: false,
 			carefulBot: false,
 			autoAcceptFollowed: false,
+			isIndexable: true,
 			saving: false,
 			avatarUploading: false,
 			bannerUploading: false,
@@ -217,6 +219,7 @@ export default Vue.extend({
 		this.isLocked = this.$store.state.i.isLocked;
 		this.carefulBot = this.$store.state.i.carefulBot;
 		this.autoAcceptFollowed = this.$store.state.i.autoAcceptFollowed;
+		this.isIndexable = this.$store.state.i.isIndexable;
 
 		this.fieldName0 = this.$store.state.i.fields[0] ? this.$store.state.i.fields[0].name : null;
 		this.fieldValue0 = this.$store.state.i.fields[0] ? this.$store.state.i.fields[0].value : null;
@@ -296,7 +299,8 @@ export default Vue.extend({
 				isBot: !!this.isBot,
 				isLocked: !!this.isLocked,
 				carefulBot: !!this.carefulBot,
-				autoAcceptFollowed: !!this.autoAcceptFollowed
+				autoAcceptFollowed: !!this.autoAcceptFollowed,
+				isIndexable: !!this.isIndexable,
 			}).then(i => {
 				this.saving = false;
 				this.$store.state.i.avatarId = i.avatarId;

--- a/src/models/entities/user.ts
+++ b/src/models/entities/user.ts
@@ -201,6 +201,12 @@ export class User {
 	@JoinColumn()
 	public movedToUser: User | null;
 
+	@Column('boolean', {
+		default: true,
+		comment: 'Search indexable.'
+	})
+	public isIndexable: boolean;
+
 	constructor(data: Partial<User>) {
 		if (data == null) return;
 

--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -222,6 +222,7 @@ export class UserRepository extends Repository<User> {
 				alwaysMarkNsfw: profile!.alwaysMarkNsfw,
 				carefulBot: profile!.carefulBot,
 				autoAcceptFollowed: profile!.autoAcceptFollowed,
+				isIndexable: user.isIndexable,
 				isDeleted: user.isDeleted,
 				hasUnreadMessagingMessage: this.getHasUnreadMessagingMessage(user.id),
 				hasUnreadNotification: this.getHasUnreadNotification(user.id),

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -159,6 +159,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 				lastFetchedAt: new Date(),
 				name: person.name ? truncate(person.name, MAX_NAME_LENGTH) : person.name,
 				isLocked: !!person.manuallyApprovesFollowers,
+				isIndexable: !(person.indexable === false),
 				username: person.preferredUsername,
 				usernameLower: person.preferredUsername!.toLowerCase(),
 				host,
@@ -337,6 +338,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 		isBot: getApType(object) === 'Service',
 		isCat: (person as any).isCat === true,
 		isLocked: !!person.manuallyApprovesFollowers,
+		isIndexable: !(person.indexable === false),
 		movedToUserId: movedTo?.id || null,
 	} as Partial<User>;
 

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -28,6 +28,7 @@ export const renderActivity = (x: any): IActivity | null => {
 				Emoji: 'toot:Emoji',
 				featured: 'toot:featured',
 				discoverable: 'toot:discoverable',
+				indexable: 'toot:indexable',
 				// schema
 				schema: 'http://schema.org#',
 				PropertyValue: 'schema:PropertyValue',

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -70,6 +70,7 @@ export async function renderPerson(user: ILocalUser) {
 		image: banner ? renderImage(banner) : null,
 		tag,
 		manuallyApprovesFollowers: user.isLocked,
+		indexable: user.isIndexable,
 		publicKey: renderKey(user, keypair, `#main-key`),
 		isCat: user.isCat,
 		attachment: attachment.length ? attachment : undefined

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -151,6 +151,7 @@ export interface IActor extends IObject {
 	name?: string;
 	preferredUsername?: string;
 	manuallyApprovesFollowers?: boolean;
+	indexable?: boolean;
 	inbox: string;
 	sharedInbox?: string;	// 後方互換性のため
 	publicKey?: {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -106,6 +106,13 @@ export const meta = {
 			}
 		},
 
+		isIndexable: {
+			validator: $.optional.bool,
+			desc: {
+				'ja-JP': '投稿検索を許可する'
+			}
+		},
+
 		isBot: {
 			validator: $.optional.bool,
 			desc: {
@@ -194,6 +201,7 @@ export default define(meta, async (ps, user, app) => {
 	if (typeof ps.isBot == 'boolean') updates.isBot = ps.isBot;
 	if (typeof ps.carefulBot == 'boolean') profileUpdates.carefulBot = ps.carefulBot;
 	if (typeof ps.autoAcceptFollowed == 'boolean') profileUpdates.autoAcceptFollowed = ps.autoAcceptFollowed;
+	if (typeof ps.isIndexable == 'boolean') updates.isIndexable = ps.isIndexable;
 	if (typeof ps.isCat == 'boolean') updates.isCat = ps.isCat;
 	if (typeof ps.autoWatch == 'boolean') profileUpdates.autoWatch = ps.autoWatch;
 	if (typeof ps.alwaysMarkNsfw == 'boolean') profileUpdates.alwaysMarkNsfw = ps.alwaysMarkNsfw;


### PR DESCRIPTION
## Summary
Resolve #2483
https://github.com/mei23/misskey-v11/commit/c7eed9af5797c319584096d77f669493aebf431e も必要
ユーザープロフィール設定に`投稿検索を許可する`を追加して、AP (Mastodon拡張) の`toot:indexable`とマップさせます。
主にMastodon 4.2以降でこちらの公開投稿が検索できるようになります。

.
.
.

前提:
元々Mastodonの投稿検索は、リアクションしたものとフォロワーからのみであり、`toot:indexable`は公開投稿の検索可否にマップされます。
元々Misskeyの投稿検索は、制限はありません。 (場所によってhomeまでだったりpublicまでだったりする)

この機能によって変わる良さげな動作:
対応したMisskeyやFedibird相手では想定通り動作します。
`投稿検索を許可する`を有効にすることにより、Mastodon 4.2以降でMisskeyの公開投稿が新たに検索対象になります。
`投稿検索を許可する`を無効にすることにより、Misskey系の対応している実装によっては検索対象から外せます。

この機能によって発生する多くのユーザーの意図と違う動作:
`投稿検索を許可する`を無効にしても、Mastodon (すべてのバージョン) ではリアクションしたものとフォロワー投稿条件は依然検索対象になります。
`投稿検索を許可する`を無効にしても、対応していないMisskey系の実装では依然検索対象になります。

結論:
Misskey系のindexable対応はカオスが増すので単純にやらないほうがいい気がするが、やっちゃったやつがいるので仕方ない。
Mastodonの検索がMisskey系の投稿だらけになりそう。