### PR TITLE
Check Signature Algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"highlight.js": "10.6.0",
 		"html-minifier": "4.0.0",
 		"http-proxy-agent": "5.0.0",
-		"http-signature": "1.3.6",
+		"@peertube/http-signature": "1.7.0",
 		"https-proxy-agent": "5.0.1",
 		"insert-text-at-cursor": "0.3.0",
 		"ip-cidr": "3.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ dependencies:
   '@koa/router':
     specifier: 8.0.8
     version: 8.0.8
+  '@peertube/http-signature':
+    specifier: 1.7.0
+    version: 1.7.0
   '@swc/core':
     specifier: 1.3.39
     version: 1.3.39
@@ -171,9 +174,6 @@ dependencies:
   http-proxy-agent:
     specifier: 5.0.0
     version: 5.0.0
-  http-signature:
-    specifier: 1.3.6
-    version: 1.3.6
   https-proxy-agent:
     specifier: 5.0.1
     version: 5.0.1
@@ -1054,6 +1054,15 @@ packages:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@peertube/http-signature@1.7.0:
+    resolution: {integrity: sha512-aGQIwo6/sWtyyqhVK4e1MtxYz4N1X8CNt6SOtCc+Wnczs5S5ONaLHDDR8LYaGn0MgOwvGgXyuZ5sJIfd7iyoUw==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
     dev: false
 
   /@redocly/ajv@8.11.0:
@@ -5641,15 +5650,6 @@ packages:
       - supports-color
     dev: false
 
-  /http-signature@1.3.6:
-    resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 2.0.2
-      sshpk: 1.17.0
-    dev: false
-
   /http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
@@ -6416,9 +6416,9 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /jsprim@2.0.2:
-    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
-    engines: {'0': node >=0.6.0}
+  /jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
     dependencies:
       assert-plus: 1.0.0
       extsprintf: 1.3.0

--- a/src/@types/http-signature.d.ts
+++ b/src/@types/http-signature.d.ts
@@ -1,4 +1,4 @@
-declare module 'http-signature' {
+declare module '@peertube/http-signature' {
 	import { IncomingMessage, ClientRequest } from 'http';
 
 	interface ISignature {

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -1,4 +1,4 @@
-import * as httpSignature from 'http-signature';
+import * as httpSignature from '@peertube/http-signature';
 
 import config from '../config';
 import { ILocalUser, User } from '../models/entities/user';

--- a/src/queue/processors/inbox.ts
+++ b/src/queue/processors/inbox.ts
@@ -1,5 +1,5 @@
 import * as Bull from 'bull';
-import * as httpSignature from 'http-signature';
+import * as httpSignature from '@peertube/http-signature';
 import perform from '../../remote/activitypub/perform';
 import Logger from '../../services/logger';
 import { registerOrFetchInstanceDoc } from '../../services/register-or-fetch-instance-doc';

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -1,5 +1,4 @@
-//import { ObjectID } from 'mongodb';
-import * as httpSignature from 'http-signature';
+import * as httpSignature from '@peertube/http-signature';
 import { ILocalUser, User } from '../models/entities/user';
 import { IActivity } from '../remote/activitypub/type';
 

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -3,7 +3,7 @@ import config from '../config';
 import * as coBody from 'co-body';
 import * as crypto from 'crypto';
 import { IActivity } from '../remote/activitypub/type';
-import * as httpSignature from 'http-signature';
+import * as httpSignature from '@peertube/http-signature';
 import Logger from '../services/logger';
 import { inspect } from 'util';
 
@@ -59,6 +59,18 @@ async function inbox(ctx: Router.RouterContext) {
 		}
 
 		return;
+	}
+
+	// Validate signature algorithm
+	if (!signature.algorithm.toLowerCase().match(/^((dsa|rsa|ecdsa)-(sha256|sha384|sha512)|ed25519-sha512|hs2019)$/)) {
+		logger.warn(`inbox: invalid signature algorithm ${signature.algorithm}`);
+		ctx.status = 401;
+		ctx.message = 'Invalid Signature Algorithm';
+		return;
+
+		// hs2019
+		// keyType=ED25519 => ed25519-sha512
+		// keyType=other => (keyType)-sha256
 	}
 
 	// Digestヘッダーの検証

--- a/test/ap-request.ts
+++ b/test/ap-request.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { genRsaKeyPair } from '../src/misc/gen-key-pair';
 import { createSignedPost, createSignedGet } from '../src/remote/activitypub/ap-request';
-const httpSignature = require('http-signature');
+const httpSignature = require('@peertube/http-signature');
 
 export const buildParsedSignature = (signingString: string, signature: string, algorithm: string) => {
 	return {


### PR DESCRIPTION
## Summary
HTTP Signatureの鍵のアルゴリズムを明確にして調整

鍵: dsa, rsa, ecdsa, ed25519(追加)
署名: md5(削除), sha1(削除), sha256, sha384, sha512

なお、ed25519の場合は常にsha512になります。

hs2019の追加
hs2019を指定した場合は
ed25519鍵が与えられた場合は、ed25519-sha512として扱い
それ以外は、鍵-sha256として扱います。