### PR TITLE
ActivityPub Deliver queueでBodyを事前処理するように

### DIFF
--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -14,6 +14,7 @@ import { getJobInfo } from './get-job-info';
 import { IActivity } from '../remote/activitypub/type';
 import { dbQueue, deliverQueue, inboxQueue, objectStorageQueue } from './queues';
 import { cpus } from 'os';
+import { createDigest } from '../remote/activitypub/ap-request';
 
 function renderError(e: Error): any {
 	return {
@@ -66,9 +67,12 @@ objectStorageQueue
 export function deliver(user: ILocalUser, content: any, to: string) {
 	if (content == null) return null;
 
+	const contentBody = JSON.stringify(content);
+
 	const data = {
 		user,
-		content,
+		content: contentBody,
+		digest: createDigest(contentBody),
 		to
 	};
 

--- a/src/queue/processors/deliver.ts
+++ b/src/queue/processors/deliver.ts
@@ -31,7 +31,7 @@ export default async (job: Bull.Job<DeliverJobData>) => {
 			logger.debug(`delivering ${latest}`);
 		}
 
-		await request(job.data.user, job.data.to, job.data.content);
+		await request(job.data.user, job.data.to, job.data.content, job.data.digest);
 
 		// Update stats
 		registerOrFetchInstanceDoc(host).then(i => {

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -6,7 +6,9 @@ export type DeliverJobData = {
 	/** Actor */
 	user: ILocalUser;
 	/** Activity */
-	content: any;
+	content: string;
+	/** Digest header */
+	digest: string;
 	/** inbox URL to deliver */
 	to: string;
 };

--- a/src/remote/activitypub/ap-request.ts
+++ b/src/remote/activitypub/ap-request.ts
@@ -11,9 +11,9 @@ type PrivateKey = {
 	keyId: string;
 };
 
-export function createSignedPost(args: { key: PrivateKey, url: string, body: string, additionalHeaders: Record<string, string> }) {
+export function createSignedPost(args: { key: PrivateKey, url: string, body: string, digest?: string, additionalHeaders: Record<string, string> }) {
 	const u = new URL(args.url);
-	const digestHeader = `SHA-256=${crypto.createHash('sha256').update(args.body).digest('base64')}`;
+	const digestHeader = args.digest ?? createDigest(args.body);
 
 	const request: Request = {
 		url: u.href,
@@ -34,6 +34,10 @@ export function createSignedPost(args: { key: PrivateKey, url: string, body: str
 		signature: result.signature,
 		signatureHeader: result.signatureHeader,
 	};
+}
+
+export function createDigest(body: string) {
+	return `SHA-256=${crypto.createHash('sha256').update(body).digest('base64')}`;
 }
 
 export function createSignedGet(args: { key: PrivateKey, url: string, additionalHeaders: Record<string, string> }) {

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -5,8 +5,8 @@ import { ILocalUser } from '../../models/entities/user';
 import { UserKeypairs } from '../../models';
 import { ensure } from '../../prelude/ensure';
 
-export default async (user: ILocalUser, url: string, object: any) => {
-	const body = JSON.stringify(object);
+export default async (user: ILocalUser, url: string, object: any, digest?: string) => {
+	const body = typeof object === 'string' ? object : JSON.stringify(object);
 
 	const keypair = await UserKeypairs.findOne({
 		userId: user.id
@@ -19,6 +19,7 @@ export default async (user: ILocalUser, url: string, object: any) => {
 		},
 		url,
 		body,
+		digest,
 		additionalHeaders: {
 			'User-Agent': config.userAgent,
 		}


### PR DESCRIPTION
## Summary
Resolve #2506

ActivityPub Deliver queueで、配信先サーバーごとに複製してキューに入れる前にJSONシリアライズとダイジェスト計算を行うように。