### PR TITLE
No findOne(id)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ MongoDBは`null`で返してきてたので、その感覚で`if (x === null)`�
 でもいちいち複数行を費やして、発生するはずのない`undefined`をチェックするのも面倒なので、`ensure`というユーティリティ関数を用意しています。
 例えば、
 ``` ts
-const user = await Users.findOne(userId);
+const user = await Users.findOne({ id: userId });
 // この時点で user の型は User | undefined
 if (user == null) {
 	throw 'missing user';
@@ -223,13 +223,13 @@ if (user == null) {
 ```
 という処理を`ensure`を使うと
 ``` ts
-const user = await Users.findOne(userId).then(ensure);
+const user = await Users.findOne({ id: userId }).then(ensure);
 // この時点で user の型は User
 ```
 という風に書けます。
 もちろん`ensure`内部でエラーを握りつぶすようなことはしておらず、万が一`undefined`だった場合はPromiseがRejectされ後続の処理は実行されません。
 ``` ts
-const user = await Users.findOne(userId).then(ensure);
+const user = await Users.findOne({ id: userId }).then(ensure);
 // 万が一 Users.findOne の結果が undefined だったら、ensure でエラーが発生するので
 // この行に到達することは無い
 // なので、.then(ensure) は

--- a/src/models/repositories/abuse-user-report.ts
+++ b/src/models/repositories/abuse-user-report.ts
@@ -9,7 +9,7 @@ export class AbuseUserReportRepository extends Repository<AbuseUserReport> {
 	public async pack(
 		src: AbuseUserReport['id'] | AbuseUserReport,
 	) {
-		const report = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const report = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: report.id,

--- a/src/models/repositories/app.ts
+++ b/src/models/repositories/app.ts
@@ -23,7 +23,7 @@ export class AppRepository extends Repository<App> {
 			includeProfileImageIds: false
 		}, options);
 
-		const app = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const app = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: app.id,

--- a/src/models/repositories/auth-session.ts
+++ b/src/models/repositories/auth-session.ts
@@ -10,7 +10,7 @@ export class AuthSessionRepository extends Repository<AuthSession> {
 		src: AuthSession['id'] | AuthSession,
 		me?: any
 	) {
-		const session = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const session = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: session.id,

--- a/src/models/repositories/blocking.ts
+++ b/src/models/repositories/blocking.ts
@@ -13,7 +13,7 @@ export class BlockingRepository extends Repository<Blocking> {
 		src: Blocking['id'] | Blocking,
 		me?: any
 	): Promise<PackedBlocking> {
-		const blocking = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const blocking = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: blocking.id,

--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -111,7 +111,7 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			self: false
 		}, options);
 
-		const file = typeof src === 'object' ? src : await this.findOne(src);
+		const file = typeof src === 'object' ? src : await this.findOne({ id: src });
 		if (file == null) return null;
 
 		const meta = await fetchMeta();

--- a/src/models/repositories/drive-folder.ts
+++ b/src/models/repositories/drive-folder.ts
@@ -26,7 +26,7 @@ export class DriveFolderRepository extends Repository<DriveFolder> {
 			detail: false
 		}, options);
 
-		const folder = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const folder = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: folder.id,

--- a/src/models/repositories/follow-request.ts
+++ b/src/models/repositories/follow-request.ts
@@ -9,7 +9,7 @@ export class FollowRequestRepository extends Repository<FollowRequest> {
 		src: FollowRequest['id'] | FollowRequest,
 		me?: any
 	) {
-		const request = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const request = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: request.id,

--- a/src/models/repositories/following.ts
+++ b/src/models/repositories/following.ts
@@ -57,7 +57,7 @@ export class FollowingRepository extends Repository<Following> {
 			populateFollower?: boolean;
 		}
 	): Promise<PackedFollowing> {
-		const following = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const following = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		if (opts == null) opts = {};
 

--- a/src/models/repositories/games/reversi/game.ts
+++ b/src/models/repositories/games/reversi/game.ts
@@ -16,7 +16,7 @@ export class ReversiGameRepository extends Repository<ReversiGame> {
 			detail: true
 		}, options);
 
-		const game = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const game = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 		const meId = me ? typeof me === 'string' ? me : me.id : null;
 
 		return {

--- a/src/models/repositories/games/reversi/matching.ts
+++ b/src/models/repositories/games/reversi/matching.ts
@@ -10,7 +10,7 @@ export class ReversiMatchingRepository extends Repository<ReversiMatching> {
 		src: ReversiMatching['id'] | ReversiMatching,
 		me: any
 	) {
-		const matching = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const matching = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: matching.id,

--- a/src/models/repositories/messaging-message.ts
+++ b/src/models/repositories/messaging-message.ts
@@ -25,7 +25,7 @@ export class MessagingMessageRepository extends Repository<MessagingMessage> {
 			populateGroup: true,
 		};
 
-		const message = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const message = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: message.id,

--- a/src/models/repositories/moderation-logs.ts
+++ b/src/models/repositories/moderation-logs.ts
@@ -9,7 +9,7 @@ export class ModerationLogRepository extends Repository<ModerationLog> {
 	public async pack(
 		src: ModerationLog['id'] | ModerationLog,
 	) {
-		const log = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const log = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: log.id,

--- a/src/models/repositories/muting.ts
+++ b/src/models/repositories/muting.ts
@@ -13,7 +13,7 @@ export class MutingRepository extends Repository<Muting> {
 		src: Muting['id'] | Muting,
 		me?: any
 	): Promise<PackedMuting> {
-		const muting = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const muting = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: muting.id,

--- a/src/models/repositories/note-favorite.ts
+++ b/src/models/repositories/note-favorite.ts
@@ -9,7 +9,7 @@ export class NoteFavoriteRepository extends Repository<NoteFavorite> {
 		src: NoteFavorite['id'] | NoteFavorite,
 		me?: any
 	) {
-		const favorite = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const favorite = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: favorite.id,

--- a/src/models/repositories/note-reaction.ts
+++ b/src/models/repositories/note-reaction.ts
@@ -12,7 +12,7 @@ export class NoteReactionRepository extends Repository<NoteReaction> {
 		src: NoteReaction['id'] | NoteReaction,
 		me?: any
 	): Promise<PackedNoteReaction> {
-		const reaction = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const reaction = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: reaction.id,

--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -94,11 +94,11 @@ export class NoteRepository extends Repository<Note> {
 		}, options);
 
 		const meId = me ? typeof me === 'string' ? me : me.id : null;
-		const note = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const note = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 		const host = note.userHost;
 
 		async function populatePoll() {
-			const poll = await Polls.findOne(note.id).then(ensure);
+			const poll = await Polls.findOne({ noteId: note.id }).then(ensure);
 			const choices = poll.choices.map(c => ({
 				text: c,
 				votes: poll.votes[poll.choices.indexOf(c)],

--- a/src/models/repositories/notification.ts
+++ b/src/models/repositories/notification.ts
@@ -12,7 +12,7 @@ export class NotificationRepository extends Repository<Notification> {
 	public async pack(
 		src: Notification['id'] | Notification,
 	): Promise<PackedNotification> {
-		const notification = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const notification = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return await awaitAll({
 			id: notification.id,

--- a/src/models/repositories/page-like.ts
+++ b/src/models/repositories/page-like.ts
@@ -9,7 +9,7 @@ export class PageLikeRepository extends Repository<PageLike> {
 		src: PageLike['id'] | PageLike,
 		me?: any
 	) {
-		const like = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const like = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: like.id,

--- a/src/models/repositories/page.ts
+++ b/src/models/repositories/page.ts
@@ -16,7 +16,7 @@ export class PageRepository extends Repository<Page> {
 		me?: User['id'] | User | null | undefined,
 	): Promise<PackedPage> {
 		const meId = me ? typeof me === 'string' ? me : me.id : null;
-		const page = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const page = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		const attachedFiles: Promise<DriveFile | undefined>[] = [];
 		const collectFile = (xs: any[]) => {

--- a/src/models/repositories/user-group-invite.ts
+++ b/src/models/repositories/user-group-invite.ts
@@ -8,7 +8,7 @@ export class UserGroupInviteRepository extends Repository<UserGroupInvite> {
 	public async pack(
 		src: UserGroupInvite['id'] | UserGroupInvite,
 	) {
-		const invite = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const invite = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		return {
 			id: invite.id,

--- a/src/models/repositories/user-group.ts
+++ b/src/models/repositories/user-group.ts
@@ -11,7 +11,7 @@ export class UserGroupRepository extends Repository<UserGroup> {
 	public async pack(
 		src: UserGroup['id'] | UserGroup,
 	): Promise<PackedUserGroup> {
-		const userGroup = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const userGroup = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		const users = await UserGroupJoinings.find({
 			userGroupId: userGroup.id

--- a/src/models/repositories/user-list.ts
+++ b/src/models/repositories/user-list.ts
@@ -11,7 +11,7 @@ export class UserListRepository extends Repository<UserList> {
 	public async pack(
 		src: UserList['id'] | UserList,
 	): Promise<PackedUserList> {
-		const userList = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+		const userList = typeof src === 'object' ? src : await this.findOne({ id: src }).then(ensure);
 
 		const users = await UserListJoinings.find({
 			userListId: userList.id

--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -122,8 +122,8 @@ export class UserRepository extends Repository<User> {
 
 		if (typeof src === 'object') {
 			user = src;
-			if (src.avatar === undefined && src.avatarId) src.avatar = await DriveFiles.findOne(src.avatarId) || null;
-			if (src.banner === undefined && src.bannerId) src.banner = await DriveFiles.findOne(src.bannerId) || null;
+			if (src.avatar === undefined && src.avatarId) src.avatar = await DriveFiles.findOne({ id: src.avatarId }) || null;
+			if (src.banner === undefined && src.bannerId) src.banner = await DriveFiles.findOne({ id: src.bannerId }) || null;
 		} else {
 			user = await this.findOneOrFail(src, {
 				relations: ['avatar', 'banner']
@@ -137,7 +137,7 @@ export class UserRepository extends Repository<User> {
 			where: { userId: user.id },
 			order: { id: 'DESC' }
 		}) : [];
-		const profile = opts.detail ? await UserProfiles.findOne(user.id).then(ensure) : null;
+		const profile = opts.detail ? await UserProfiles.findOne({ id: user.id }).then(ensure) : null;
 
 		const falsy = opts.detail ? false : undefined;
 

--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -137,7 +137,7 @@ export class UserRepository extends Repository<User> {
 			where: { userId: user.id },
 			order: { id: 'DESC' }
 		}) : [];
-		const profile = opts.detail ? await UserProfiles.findOne({ id: user.id }).then(ensure) : null;
+		const profile = opts.detail ? await UserProfiles.findOne({ userId: user.id }).then(ensure) : null;
 
 		const falsy = opts.detail ? false : undefined;
 

--- a/src/queue/processors/db/delete-account.ts
+++ b/src/queue/processors/db/delete-account.ts
@@ -12,7 +12,7 @@ const logger = queueLogger.createSubLogger('delete-account');
 export async function deleteAccount(job: Bull.Job<DbUserJobData>): Promise<string | void> {
 	logger.info(`Deleting account of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		return;
 	}

--- a/src/queue/processors/db/delete-drive-files.ts
+++ b/src/queue/processors/db/delete-drive-files.ts
@@ -11,7 +11,7 @@ const logger = queueLogger.createSubLogger('delete-drive-files');
 export async function deleteDriveFiles(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Deleting drive files of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/export-blocking.ts
+++ b/src/queue/processors/db/export-blocking.ts
@@ -15,7 +15,7 @@ const logger = queueLogger.createSubLogger('export-blocking');
 export async function exportBlocking(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Exporting blocking of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/export-following.ts
+++ b/src/queue/processors/db/export-following.ts
@@ -15,7 +15,7 @@ const logger = queueLogger.createSubLogger('export-following');
 export async function exportFollowing(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Exporting following of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/export-mute.ts
+++ b/src/queue/processors/db/export-mute.ts
@@ -15,7 +15,7 @@ const logger = queueLogger.createSubLogger('export-mute');
 export async function exportMute(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Exporting mute of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/export-notes.ts
+++ b/src/queue/processors/db/export-notes.ts
@@ -17,7 +17,7 @@ const logger = queueLogger.createSubLogger('export-notes');
 export async function exportNotes(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Exporting notes of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/export-user-lists.ts
+++ b/src/queue/processors/db/export-user-lists.ts
@@ -15,7 +15,7 @@ const logger = queueLogger.createSubLogger('export-user-lists');
 export async function exportUserLists(job: Bull.Job<DbUserJobData>, done: any): Promise<void> {
 	logger.info(`Exporting user lists of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/import-blocking.ts
+++ b/src/queue/processors/db/import-blocking.ts
@@ -14,7 +14,7 @@ const logger = queueLogger.createSubLogger('import-blocking');
 export async function importBlocking(job: Bull.Job<DbUserImportJobData>, done: any): Promise<void> {
 	logger.info(`Importing blocking of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/import-following.ts
+++ b/src/queue/processors/db/import-following.ts
@@ -14,7 +14,7 @@ const logger = queueLogger.createSubLogger('import-following');
 export async function importFollowing(job: Bull.Job<DbUserImportJobData>, done: any): Promise<void> {
 	logger.info(`Importing following of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/queue/processors/db/import-user-lists.ts
+++ b/src/queue/processors/db/import-user-lists.ts
@@ -15,7 +15,7 @@ const logger = queueLogger.createSubLogger('import-user-lists');
 export async function importUserLists(job: Bull.Job<DbUserImportJobData>, done: any): Promise<void> {
 	logger.info(`Importing user lists of ${job.data.user.id} ...`);
 
-	const user = await Users.findOne(job.data.user.id);
+	const user = await Users.findOne({ id: job.data.user.id });
 	if (user == null) {
 		done();
 		return;

--- a/src/remote/activitypub/db-resolver.ts
+++ b/src/remote/activitypub/db-resolver.ts
@@ -82,7 +82,7 @@ export default class DbResolver {
 
 		if (key == null) return null;
 
-		const user = await Users.findOne(key.userId) as IRemoteUser;
+		const user = await Users.findOne({ id: key.userId }) as IRemoteUser;
 
 		return {
 			user,
@@ -98,7 +98,7 @@ export default class DbResolver {
 
 		if (user == null) return null;
 
-		const key = await UserPublickeys.findOne(user.id);
+		const key = await UserPublickeys.findOne({ userId: user.id });
 
 		return {
 			user,

--- a/src/remote/activitypub/kernel/read.ts
+++ b/src/remote/activitypub/kernel/read.ts
@@ -13,7 +13,7 @@ export const performReadActivity = async (actor: IRemoteUser, activity: IRead): 
 
 	const messageId = id.split('/').pop();
 
-	const message = await MessagingMessages.findOne(messageId);
+	const message = await MessagingMessages.findOne({ id: messageId });
 	if (message == null) {
 		return `skip: message not found`;
 	}

--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -40,7 +40,7 @@ export async function createImage(actor: IRemoteUser, value: any): Promise<Drive
 				uri: image.url
 			});
 
-			file = await DriveFiles.findOne(file.id).then(ensure);
+			file = await DriveFiles.findOne({ id: file.id }).then(ensure);
 		}
 	}
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -142,7 +142,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 			const uri = getApId(note.inReplyTo);
 			if (isSelfOrigin(uri)) {
 				const id = uri.split('/').pop();
-				const talk = await MessagingMessages.findOne(id);
+				const talk = await MessagingMessages.findOne({ id: id });
 				if (talk) {
 					isTalk = true;
 					return null;
@@ -202,7 +202,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 
 	// vote
 	if (reply && reply.hasPoll) {
-		const poll = await Polls.findOne(reply.id).then(ensure);
+		const poll = await Polls.findOne({ noteId: reply.id }).then(ensure);
 
 		const tryCreateVote = async (name: string, index: number): Promise<null> => {
 			if (poll.expiresAt && Date.now() > new Date(poll.expiresAt).getTime()) {

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -98,7 +98,7 @@ export async function fetchPerson(uri: string, resolver?: Resolver): Promise<Use
 	// URIがこのサーバーを指しているならデータベースからフェッチ
 	if (isSelfOrigin(uri)) {
 		const id = uri.split('/').pop();
-		return await Users.findOne(id).then(x => x || null);
+		return await Users.findOne({ id: id }).then(x => x || null);
 	}
 
 	//#region このサーバーに既に登録されていたらそれを返す
@@ -435,7 +435,7 @@ export function analyzeAttachments(attachments: IObject | IObject[] | undefined)
 }
 
 export async function updateFeatured(userId: User['id'], resolver?: Resolver) {
-	const user = await Users.findOne(userId).then(ensure);
+	const user = await Users.findOne({ id: userId }).then(ensure);
 	if (!Users.isRemoteUser(user)) return;
 	if (!user.featured) return;
 

--- a/src/remote/activitypub/renderer/follow-user.ts
+++ b/src/remote/activitypub/renderer/follow-user.ts
@@ -8,6 +8,6 @@ import { ensure } from '../../../prelude/ensure';
  * @param id Follower|Followee ID
  */
 export default async function renderFollowUser(id: User['id']): Promise<any> {
-	const user = await Users.findOne(id).then(ensure);
+	const user = await Users.findOne({ id: id }).then(ensure);
 	return Users.isLocalUser(user) ? `${config.url}/users/${user.id}` : user.uri;
 }

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -28,21 +28,21 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 	let inReplyTo: string | null;
 
 	if (note.replyId) {
-		const inReplyToNote = note.reply || await Notes.findOne(note.replyId);
+		const inReplyToNote = note.reply || await Notes.findOne({ id: note.replyId });
 		inReplyTo = inReplyToNote ? (inReplyToNote.uri || `${config.url}/notes/${inReplyToNote.id}`) : null;
 	}
 
 	let quote;
 
 	if (note.renoteId) {
-		const renote = await Notes.findOne(note.renoteId);
+		const renote = await Notes.findOne({ id: note.renoteId });
 
 		if (renote) {
 			quote = renote.uri ? renote.uri : `${config.url}/notes/${renote.id}`;
 		}
 	}
 
-	const user = await Users.findOne(note.userId).then(ensure);
+	const user = await Users.findOne({ id: note.userId }).then(ensure);
 
 	const attributedTo = `${config.url}/users/${user.id}`;
 

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -16,9 +16,9 @@ export async function renderPerson(user: ILocalUser) {
 	const isSystem = !!user.username.match(/\./);
 
 	const [avatar, banner, profile] = await Promise.all([
-		(user.avatar === undefined && user.avatarId) ? DriveFiles.findOne(user.avatarId) : user.avatar,
-		(user.banner === undefined && user.bannerId) ? DriveFiles.findOne(user.bannerId) : user.banner,
-		UserProfiles.findOne(user.id).then(ensure)
+		(user.avatar === undefined && user.avatarId) ? DriveFiles.findOne({ id: user.avatarId }) : user.avatar,
+		(user.banner === undefined && user.bannerId) ? DriveFiles.findOne({ id: user.bannerId }) : user.banner,
+		UserProfiles.findOne({ userId: user.id }).then(ensure)
 	]);
 
 	const attachment: {
@@ -50,7 +50,7 @@ export async function renderPerson(user: ILocalUser) {
 		...hashtagTags,
 	];
 
-	const keypair = await UserKeypairs.findOne(user.id).then(ensure);
+	const keypair = await UserKeypairs.findOne({ userId: user.id }).then(ensure);
 
 	return {
 		type: isSystem ? 'Application' : user.isBot ? 'Service' : 'Person',

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -225,7 +225,7 @@ router.get('/users/:user/publickey', async ctx => {
 		return;
 	}
 
-	const keypair = await UserKeypairs.findOne(user.id).then(ensure);
+	const keypair = await UserKeypairs.findOne({ userId: user.id }).then(ensure);
 
 	if (Users.isLocalUser(user)) {
 		ctx.body = renderActivity(renderKey(user, keypair));

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -101,7 +101,7 @@ export default async (ctx: Router.RouterContext) => {
  */
 export async function packActivity(note: Note): Promise<any> {
 	if (note.renoteId && note.text == null && !note.hasPoll && (note.fileIds == null || note.fileIds.length === 0)) {
-		const renote = await Notes.findOne(note.renoteId).then(ensure);
+		const renote = await Notes.findOne({ id: note.renoteId }).then(ensure);
 		return renderAnnounce(renote.uri ? renote.uri : `${config.url}/notes/${renote.id}`, note);
 	}
 

--- a/src/server/api/authenticate.ts
+++ b/src/server/api/authenticate.ts
@@ -35,11 +35,11 @@ export default async (token: string): Promise<[User | null | undefined, App | nu
 		}
 
 		const app = await Apps
-			.findOne(accessToken.appId);
+			.findOne({ id: accessToken.appId });
 
 		const user = await Users
 			.findOne({
-				id: accessToken.userId // findOne(accessToken.userId) のように書かないのは後方互換性のため
+				id: accessToken.userId // findOne({ id: accessToken.userId }) のように書かないのは後方互換性のため
 			});
 
 		return [user, app];

--- a/src/server/api/common/getters.ts
+++ b/src/server/api/common/getters.ts
@@ -34,7 +34,7 @@ import { Notes, Users } from '../../../models';
  * Get user for API processing
  */
 export async function getUser(userId: User['id']) {
-	const user = await Users.findOne(userId);
+	const user = await Users.findOne({ id: userId });
 
 	if (user == null) {
 		throw new IdentifiableError('15348ddd-432d-49c2-8a5a-8069753becff', 'No such user.');

--- a/src/server/api/endpoints/admin/drive/show-file.ts
+++ b/src/server/api/endpoints/admin/drive/show-file.ts
@@ -26,7 +26,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, me) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) {
 		throw new ApiError(meta.errors.noSuchFile);

--- a/src/server/api/endpoints/admin/emoji/remove.ts
+++ b/src/server/api/endpoints/admin/emoji/remove.ts
@@ -32,7 +32,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, me) => {
-	const emoji = await Emojis.findOne(ps.id);
+	const emoji = await Emojis.findOne({ id: ps.id });
 
 	if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
 

--- a/src/server/api/endpoints/admin/emoji/update.ts
+++ b/src/server/api/endpoints/admin/emoji/update.ts
@@ -48,7 +48,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps) => {
-	const emoji = await Emojis.findOne(ps.id);
+	const emoji = await Emojis.findOne({ id: ps.id });
 
 	if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
 

--- a/src/server/api/endpoints/admin/federation/remove-all-following.ts
+++ b/src/server/api/endpoints/admin/federation/remove-all-following.ts
@@ -23,8 +23,8 @@ export default define(meta, async (ps, me) => {
 	});
 
 	const pairs = await Promise.all(followings.map(f => Promise.all([
-		Users.findOne(f.followerId).then(ensure),
-		Users.findOne(f.followeeId).then(ensure)
+		Users.findOne({ id: f.followerId }).then(ensure),
+		Users.findOne({ id: f.followeeId }).then(ensure)
 	])));
 
 	for (const pair of pairs) {

--- a/src/server/api/endpoints/admin/remove-abuse-user-report.ts
+++ b/src/server/api/endpoints/admin/remove-abuse-user-report.ts
@@ -17,7 +17,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps) => {
-	const report = await AbuseUserReports.findOne(ps.reportId);
+	const report = await AbuseUserReports.findOne({ id: ps.reportId });
 
 	if (report == null) {
 		throw new Error('report not found');

--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -59,7 +59,7 @@ async function fetchAny(uri: string) {
 		const type = parts.pop();
 
 		if (type === 'notes') {
-			const note = await Notes.findOne(id);
+			const note = await Notes.findOne({ id: id });
 
 			if (note) {
 				return {
@@ -68,7 +68,7 @@ async function fetchAny(uri: string) {
 				};
 			}
 		} else if (type === 'users') {
-			const user = await Users.findOne(id);
+			const user = await Users.findOne({ id: id });
 
 			if (user) {
 				return {
@@ -107,7 +107,7 @@ async function fetchAny(uri: string) {
 			const type = parts.pop();
 
 			if (type === 'notes') {
-				const note = await Notes.findOne(id);
+				const note = await Notes.findOne({ id: id });
 
 				if (note) {
 					return {
@@ -116,7 +116,7 @@ async function fetchAny(uri: string) {
 					};
 				}
 			} else if (type === 'users') {
-				const user = await Users.findOne(id);
+				const user = await Users.findOne({ id: id });
 
 				if (user) {
 					return {

--- a/src/server/api/endpoints/app/show.ts
+++ b/src/server/api/endpoints/app/show.ts
@@ -32,7 +32,7 @@ export default define(meta, async (ps, user, app) => {
 	const isSecure = user != null && app == null;
 
 	// Lookup app
-	const ap = await Apps.findOne(ps.appId);
+	const ap = await Apps.findOne({ id: ps.appId });
 
 	if (ap == null) {
 		throw new ApiError(meta.errors.noSuchApp);

--- a/src/server/api/endpoints/auth/accept.ts
+++ b/src/server/api/endpoints/auth/accept.ts
@@ -49,7 +49,7 @@ export default define(meta, async (ps, user) => {
 
 	if (exist == null) {
 		// Lookup app
-		const app = await Apps.findOne(session.appId).then(ensure);
+		const app = await Apps.findOne({ id: session.appId }).then(ensure);
 
 		// Generate Hash
 		const sha256 = crypto.createHash('sha256');

--- a/src/server/api/endpoints/drive/files/delete.ts
+++ b/src/server/api/endpoints/drive/files/delete.ts
@@ -46,7 +46,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) {
 		throw new ApiError(meta.errors.noSuchFile);

--- a/src/server/api/endpoints/drive/files/show.ts
+++ b/src/server/api/endpoints/drive/files/show.ts
@@ -68,7 +68,7 @@ export default define(meta, async (ps, user) => {
 	let file: DriveFile | undefined;
 
 	if (ps.fileId) {
-		file = await DriveFiles.findOne(ps.fileId);
+		file = await DriveFiles.findOne({ id: ps.fileId });
 	} else if (ps.url) {
 		file = await DriveFiles.findOne({
 			where: [{

--- a/src/server/api/endpoints/drive/files/update.ts
+++ b/src/server/api/endpoints/drive/files/update.ts
@@ -74,7 +74,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) {
 		throw new ApiError(meta.errors.noSuchFile);

--- a/src/server/api/endpoints/games/reversi/games/show.ts
+++ b/src/server/api/endpoints/games/reversi/games/show.ts
@@ -24,7 +24,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const game = await ReversiGames.findOne(ps.gameId);
+	const game = await ReversiGames.findOne({ id: ps.gameId });
 
 	if (game == null) {
 		throw new ApiError(meta.errors.noSuchGame);

--- a/src/server/api/endpoints/games/reversi/games/surrender.ts
+++ b/src/server/api/endpoints/games/reversi/games/surrender.ts
@@ -45,7 +45,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const game = await ReversiGames.findOne(ps.gameId);
+	const game = await ReversiGames.findOne({ id: ps.gameId });
 
 	if (game == null) {
 		throw new ApiError(meta.errors.noSuchGame);

--- a/src/server/api/endpoints/i/2fa/done.ts
+++ b/src/server/api/endpoints/i/2fa/done.ts
@@ -19,7 +19,7 @@ export const meta = {
 export default define(meta, async (ps, user) => {
 	const token = ps.token.replace(/\s/g, '');
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	if (profile.twoFactorTempSecret == null) {
 		throw new Error('二段階認証の設定が開始されていません');

--- a/src/server/api/endpoints/i/2fa/key-done.ts
+++ b/src/server/api/endpoints/i/2fa/key-done.ts
@@ -43,7 +43,7 @@ export const meta = {
 const rpIdHashReal = hash(Buffer.from(config.hostname, 'utf-8'));
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/2fa/register-key.ts
+++ b/src/server/api/endpoints/i/2fa/register-key.ts
@@ -23,7 +23,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/2fa/register.ts
+++ b/src/server/api/endpoints/i/2fa/register.ts
@@ -20,7 +20,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/2fa/remove-key.ts
+++ b/src/server/api/endpoints/i/2fa/remove-key.ts
@@ -21,7 +21,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/2fa/unregister.ts
+++ b/src/server/api/endpoints/i/2fa/unregister.ts
@@ -17,7 +17,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/change-password.ts
+++ b/src/server/api/endpoints/i/change-password.ts
@@ -21,7 +21,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.currentPassword, profile.password!);

--- a/src/server/api/endpoints/i/import-blocking.ts
+++ b/src/server/api/endpoints/i/import-blocking.ts
@@ -48,7 +48,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) throw new ApiError(meta.errors.noSuchFile);
 	//if (!file.type.endsWith('/csv')) throw new ApiError(meta.errors.unexpectedFileType);

--- a/src/server/api/endpoints/i/import-following.ts
+++ b/src/server/api/endpoints/i/import-following.ts
@@ -48,7 +48,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) throw new ApiError(meta.errors.noSuchFile);
 	//if (!file.type.endsWith('/csv')) throw new ApiError(meta.errors.unexpectedFileType);

--- a/src/server/api/endpoints/i/import-user-lists.ts
+++ b/src/server/api/endpoints/i/import-user-lists.ts
@@ -48,7 +48,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const file = await DriveFiles.findOne(ps.fileId);
+	const file = await DriveFiles.findOne({ id: ps.fileId });
 
 	if (file == null) throw new ApiError(meta.errors.noSuchFile);
 	//if (!file.type.endsWith('/csv')) throw new ApiError(meta.errors.unexpectedFileType);

--- a/src/server/api/endpoints/i/regenerate-token.ts
+++ b/src/server/api/endpoints/i/regenerate-token.ts
@@ -20,7 +20,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/update-client-setting.ts
+++ b/src/server/api/endpoints/i/update-client-setting.ts
@@ -21,7 +21,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	await UserProfiles.createQueryBuilder().update()
 		.set({

--- a/src/server/api/endpoints/i/update-email.ts
+++ b/src/server/api/endpoints/i/update-email.ts
@@ -40,7 +40,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(ps.password, profile.password!);

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -195,7 +195,7 @@ export default define(meta, async (ps, user, app) => {
 	const updates = {} as Partial<User>;
 	const profileUpdates = {} as Partial<UserProfile>;
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	if (ps.name !== undefined) updates.name = ps.name;
 	if (ps.description !== undefined) profileUpdates.description = ps.description;
@@ -215,21 +215,21 @@ export default define(meta, async (ps, user, app) => {
 	if (typeof ps.alwaysMarkNsfw == 'boolean') profileUpdates.alwaysMarkNsfw = ps.alwaysMarkNsfw;
 
 	if (ps.avatarId) {
-		const avatar = await DriveFiles.findOne(ps.avatarId);
+		const avatar = await DriveFiles.findOne({ id: ps.avatarId });
 
 		if (avatar == null || avatar.userId !== user.id) throw new ApiError(meta.errors.noSuchAvatar);
 		if (!avatar.type.startsWith('image/')) throw new ApiError(meta.errors.avatarNotAnImage);
 	}
 
 	if (ps.bannerId) {
-		const banner = await DriveFiles.findOne(ps.bannerId);
+		const banner = await DriveFiles.findOne({ id: ps.bannerId });
 
 		if (banner == null || banner.userId !== user.id) throw new ApiError(meta.errors.noSuchBanner);
 		if (!banner.type.startsWith('image/')) throw new ApiError(meta.errors.bannerNotAnImage);
 	}
 
 	if (ps.pinnedPageId) {
-		const page = await Pages.findOne(ps.pinnedPageId);
+		const page = await Pages.findOne({ id: ps.pinnedPageId });
 
 		if (page == null || page.userId !== user.id) throw new ApiError(meta.errors.noSuchPage);
 

--- a/src/server/api/endpoints/messaging/messages.ts
+++ b/src/server/api/endpoints/messaging/messages.ts
@@ -126,7 +126,7 @@ export default define(meta, async (ps, user) => {
 		})));
 	} else if (ps.groupId != null) {
 		// Fetch recipient (group)
-		const recipientGroup = await UserGroups.findOne(ps.groupId);
+		const recipientGroup = await UserGroups.findOne({ id: ps.groupId });
 
 		if (recipientGroup == null) {
 			throw new ApiError(meta.errors.noSuchGroup);

--- a/src/server/api/endpoints/messaging/messages/create.ts
+++ b/src/server/api/endpoints/messaging/messages/create.ts
@@ -108,7 +108,7 @@ export default define(meta, async (ps, user) => {
 		});
 	} else if (ps.groupId != null) {
 		// Fetch recipient (group)
-		recipientGroup = await UserGroups.findOne(ps.groupId);
+		recipientGroup = await UserGroups.findOne({ id: ps.groupId });
 
 		if (recipientGroup == null) {
 			throw new ApiError(meta.errors.noSuchGroup);

--- a/src/server/api/endpoints/notes/conversation.ts
+++ b/src/server/api/endpoints/notes/conversation.ts
@@ -66,7 +66,7 @@ export default define(meta, async (ps, user) => {
 
 	async function get(id: any) {
 		i++;
-		const p = await Notes.findOne(id);
+		const p = await Notes.findOne({ id: id });
 		if (p == null) return;
 
 		if (i > ps.offset!) {

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -231,7 +231,7 @@ export const meta = {
 export default define(meta, async (ps, user, app) => {
 	let visibleUsers: User[] = [];
 	if (ps.visibleUserIds) {
-		visibleUsers = (await Promise.all(ps.visibleUserIds.map(id => Users.findOne(id))))
+		visibleUsers = (await Promise.all(ps.visibleUserIds.map(id => Users.findOne({ id: id }))))
 			.filter(x => x != null) as User[];
 	}
 
@@ -249,7 +249,7 @@ export default define(meta, async (ps, user, app) => {
 	let renote: Note | undefined;
 	if (ps.renoteId != null) {
 		// Fetch renote to note
-		renote = await Notes.findOne(ps.renoteId);
+		renote = await Notes.findOne({ id: ps.renoteId });
 
 		if (renote == null) {
 			throw new ApiError(meta.errors.noSuchRenoteTarget);
@@ -261,7 +261,7 @@ export default define(meta, async (ps, user, app) => {
 	let reply: Note | undefined;
 	if (ps.replyId != null) {
 		// Fetch reply
-		reply = await Notes.findOne(ps.replyId);
+		reply = await Notes.findOne({ id: ps.replyId });
 
 		if (reply == null) {
 			throw new ApiError(meta.errors.noSuchReplyTarget);

--- a/src/server/api/endpoints/notes/delete.ts
+++ b/src/server/api/endpoints/notes/delete.ts
@@ -64,5 +64,5 @@ export default define(meta, async (ps, user) => {
 	}
 
 	// この操作を行うのが投稿者とは限らない(例えばモデレーター)ため
-	await deleteNote(await Users.findOne(note.userId).then(ensure), note);
+	await deleteNote(await Users.findOne({ id: note.userId }).then(ensure), note);
 });

--- a/src/server/api/endpoints/notes/polls/vote.ts
+++ b/src/server/api/endpoints/notes/polls/vote.ts
@@ -150,7 +150,7 @@ export default define(meta, async (ps, user) => {
 		}
 	});
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// この投稿をWatchする
 	if (profile.autoWatch !== false) {
@@ -159,7 +159,7 @@ export default define(meta, async (ps, user) => {
 
 	// リモート投票の場合リプライ送信
 	if (note.userHost != null) {
-		const pollOwner = await Users.findOne(note.userId).then(ensure) as IRemoteUser;
+		const pollOwner = await Users.findOne({ id: note.userId }).then(ensure) as IRemoteUser;
 
 		deliver(user, renderActivity(await renderVote(user, vote, note, poll, pollOwner)), pollOwner.inbox);
 	}

--- a/src/server/api/endpoints/page-push.ts
+++ b/src/server/api/endpoints/page-push.ts
@@ -33,7 +33,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const page = await Pages.findOne(ps.pageId);
+	const page = await Pages.findOne({ id: ps.pageId });
 	if (page == null) {
 		throw new ApiError(meta.errors.noSuchPage);
 	}

--- a/src/server/api/endpoints/pages/delete.ts
+++ b/src/server/api/endpoints/pages/delete.ts
@@ -41,7 +41,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const page = await Pages.findOne(ps.pageId);
+	const page = await Pages.findOne({ id: ps.pageId });
 	if (page == null) {
 		throw new ApiError(meta.errors.noSuchPage);
 	}

--- a/src/server/api/endpoints/pages/like.ts
+++ b/src/server/api/endpoints/pages/like.ts
@@ -48,7 +48,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const page = await Pages.findOne(ps.pageId);
+	const page = await Pages.findOne({ id: ps.pageId });
 	if (page == null) {
 		throw new ApiError(meta.errors.noSuchPage);
 	}

--- a/src/server/api/endpoints/pages/show.ts
+++ b/src/server/api/endpoints/pages/show.ts
@@ -51,7 +51,7 @@ export default define(meta, async (ps, user) => {
 	let page: Page | undefined;
 
 	if (ps.pageId) {
-		page = await Pages.findOne(ps.pageId);
+		page = await Pages.findOne({ id: ps.pageId });
 	} else if (ps.name && ps.username) {
 		const author = await Users.findOne({
 			host: null,

--- a/src/server/api/endpoints/pages/unlike.ts
+++ b/src/server/api/endpoints/pages/unlike.ts
@@ -41,7 +41,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const page = await Pages.findOne(ps.pageId);
+	const page = await Pages.findOne({ id: ps.pageId });
 	if (page == null) {
 		throw new ApiError(meta.errors.noSuchPage);
 	}

--- a/src/server/api/endpoints/pages/update.ts
+++ b/src/server/api/endpoints/pages/update.ts
@@ -95,7 +95,7 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	const page = await Pages.findOne(ps.pageId);
+	const page = await Pages.findOne({ id: ps.pageId });
 	if (page == null) {
 		throw new ApiError(meta.errors.noSuchPage);
 	}

--- a/src/server/api/endpoints/room/show.ts
+++ b/src/server/api/endpoints/room/show.ts
@@ -51,7 +51,7 @@ export default define(meta, async (ps, me) => {
 		throw new ApiError(meta.errors.noSuchUser);
 	}
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	if (profile.room.furnitures == null) {
 		await UserProfiles.update({ userId: user.id }, {

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -95,7 +95,7 @@ export default define(meta, async (ps, me) => {
 				? { id: ps.userId }
 				: { usernameLower: ps.username!.toLowerCase(), host: null };
 
-			user = await Users.findOne(q);
+			user = await Users.findOne({ id: q });
 		}
 
 		if (user == null || (!isAdminOrModerator && user.isSuspended)) {

--- a/src/server/api/private/signin.ts
+++ b/src/server/api/private/signin.ts
@@ -54,7 +54,7 @@ export default async (ctx: Koa.Context) => {
 		return;
 	}
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	// Compare password
 	const same = await bcrypt.compare(password, profile.password!);

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -206,7 +206,7 @@ router.get('/dc/cb', async ctx => {
 			discordDiscriminator: discriminator
 		});
 
-		signin(ctx, await Users.findOne(profile.userId) as ILocalUser, true);
+		signin(ctx, await Users.findOne({ id: profile.userId }) as ILocalUser, true);
 	} else {
 		const code = ctx.query.code;
 

--- a/src/server/api/service/github.ts
+++ b/src/server/api/service/github.ts
@@ -186,7 +186,7 @@ router.get('/gh/cb', async ctx => {
 			return;
 		}
 
-		signin(ctx, await Users.findOne(link.userId) as ILocalUser, true);
+		signin(ctx, await Users.findOne({ id: link.userId }) as ILocalUser, true);
 	} else {
 		const code = ctx.query.code;
 

--- a/src/server/api/service/twitter.ts
+++ b/src/server/api/service/twitter.ts
@@ -146,7 +146,7 @@ router.get('/tw/cb', async ctx => {
 			return;
 		}
 
-		signin(ctx, await Users.findOne(link.userId) as ILocalUser, true);
+		signin(ctx, await Users.findOne({ id: link.userId }) as ILocalUser, true);
 	} else {
 		const verifier = ctx.query.oauth_verifier;
 

--- a/src/server/api/stream/channels/messaging.ts
+++ b/src/server/api/stream/channels/messaging.ts
@@ -50,7 +50,7 @@ export default class extends Channel {
 
 					// リモートユーザーからのメッセージだったら既読配信
 					if (Users.isLocalUser(this.user!) && Users.isRemoteUser(this.otherparty!)) {
-						MessagingMessages.findOne(body.id).then(message => {
+						MessagingMessages.findOne({ id: body.id }).then(message => {
 							if (message) deliverReadActivity(this.user as ILocalUser, this.otherparty as IRemoteUser, message);
 						});
 					}

--- a/src/server/api/stream/index.ts
+++ b/src/server/api/stream/index.ts
@@ -74,7 +74,7 @@ export default class Connection {
 	@autobind
 	private async onApiRequest(payload: any) {
 		// 新鮮なデータを利用するためにユーザーをフェッチ
-		const user = this.user ? await Users.findOne(this.user.id) : null;
+		const user = this.user ? await Users.findOne({ id: this.user.id }) : null;
 
 		const endpoint = payload.endpoint || payload.ep; // alias
 

--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -11,7 +11,7 @@ export default async function(user: User) {
 		name: user.name || user.username
 	};
 
-	const profile = await UserProfiles.findOne(user.id).then(ensure);
+	const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 	const notes = await Notes.find({
 		where: {

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -172,7 +172,7 @@ router.get(['/@:user', '/@:user/:sub'], async (ctx, next) => {
 	const user = await Users.pack(_user!);
 
 	if (user != null) {
-		const profile = await UserProfiles.findOne(user.id).then(ensure);
+		const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 		const meta = await fetchMeta();
 		const me = profile.fields
 			? profile.fields
@@ -216,7 +216,7 @@ router.get('/users/:user', async ctx => {
 
 // Note
 router.get('/notes/:note', async ctx => {
-	const note = await Notes.findOne(ctx.params.note);
+	const note = await Notes.findOne({ id: ctx.params.note });
 
 	if (note) {
 		const _note = await Notes.pack(note);
@@ -272,7 +272,7 @@ router.get('/notes/:note', async ctx => {
 router.get('/notes/:note/embed', async ctx => {
 	ctx.remove('X-Frame-Options');
 
-	const note = await Notes.findOne(ctx.params.note);
+	const note = await Notes.findOne({ id: ctx.params.note });
 
 	if (note) {
 		const _note = await Notes.pack(note);

--- a/src/services/create-notification.ts
+++ b/src/services/create-notification.ts
@@ -46,7 +46,7 @@ export async function createNotification(
 
 	// 2秒経っても(今回作成した)通知が既読にならなかったら「未読の通知がありますよ」イベントを発行する
 	setTimeout(async () => {
-		const fresh = await Notifications.findOne(notification.id);
+		const fresh = await Notifications.findOne({ id: notification.id });
 		if (fresh == null) return; // 既に削除されているかもしれない
 		if (!fresh.isRead) {
 			//#region ただしミュートしているユーザーからの通知なら無視

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -393,7 +393,7 @@ export default async function(
 		properties['height'] = info.height;
 	}
 
-	const profile = await UserProfiles.findOne(user.id);
+	const profile = await UserProfiles.findOne({ userId: user.id });
 
 	const folder = await fetchFolder();
 

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -117,7 +117,7 @@ export default async function(follower: User, followee: User, requestId?: string
 		if (blocked != null) throw new IdentifiableError('3338392a-f764-498d-8855-db939dcf8c48', 'blocked');
 	}
 
-	const followeeProfile = await UserProfiles.findOne(followee.id).then(ensure);
+	const followeeProfile = await UserProfiles.findOne({ userId: followee.id }).then(ensure);
 
 	// フォロー対象が鍵アカウントである or
 	// フォロワーがBotであり、フォロー対象がBotからのフォローに慎重である or

--- a/src/services/following/requests/accept-all.ts
+++ b/src/services/following/requests/accept-all.ts
@@ -13,7 +13,7 @@ export default async function(user: User) {
 	});
 
 	for (const request of requests) {
-		const follower = await Users.findOne(request.followerId).then(ensure);
+		const follower = await Users.findOne({ id: request.followerId }).then(ensure);
 		accept(user, follower);
 	}
 }

--- a/src/services/i/pin.ts
+++ b/src/services/i/pin.ts
@@ -78,7 +78,7 @@ export async function removePinned(user: User, noteId: Note['id']) {
 }
 
 export async function deliverPinnedChange(userId: User['id'], noteId: Note['id'], isAddition: boolean) {
-	const user = await Users.findOne(userId);
+	const user = await Users.findOne({ id: userId });
 	if (user == null) throw new Error('user not found');
 
 	if (!Users.isLocalUser(user)) return;

--- a/src/services/i/update.ts
+++ b/src/services/i/update.ts
@@ -7,7 +7,7 @@ import { deliverToFollowers } from '../../remote/activitypub/deliver-manager';
 import { deliverToRelays } from '../relay';
 
 export async function publishToFollowers(userId: User['id']) {
-	const user = await Users.findOne(userId);
+	const user = await Users.findOne({ id: userId });
 	if (user == null) throw new Error('user not found');
 
 	// フォロワーがリモートユーザーかつ投稿者がローカルユーザーならUpdateを配信

--- a/src/services/messages/create.ts
+++ b/src/services/messages/create.ts
@@ -57,7 +57,7 @@ export async function createMessage(user: User, recipientUser: User | undefined,
 
 	// 2秒経っても(今回作成した)メッセージが既読にならなかったら「未読のメッセージがありますよ」イベントを発行する
 	setTimeout(async () => {
-		const freshMessage = await MessagingMessages.findOne(message.id);
+		const freshMessage = await MessagingMessages.findOne({ id: message.id });
 		if (freshMessage == null) return; // メッセージが削除されている場合もある
 
 		if (recipientUser && Users.isLocalUser(recipientUser)) {

--- a/src/services/messages/delete.ts
+++ b/src/services/messages/delete.ts
@@ -15,8 +15,8 @@ export async function deleteMessage(message: MessagingMessage) {
 
 async function postDeleteMessage(message: MessagingMessage) {
 	if (message.recipientId) {
-		const user = await Users.findOne(message.userId).then(ensure);
-		const recipient = await Users.findOne(message.recipientId).then(ensure);
+		const user = await Users.findOne({ id: message.userId }).then(ensure);
+		const recipient = await Users.findOne({ id: message.recipientId }).then(ensure);
 
 		if (Users.isLocalUser(user)) publishMessagingStream(message.userId, message.recipientId, 'deleted', message.id);
 		if (Users.isLocalUser(recipient)) publishMessagingStream(message.recipientId, message.userId, 'deleted', message.id);

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -170,7 +170,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 	tags = tags.filter(tag => Array.from(tag || '').length <= 128).splice(0, 32);
 
 	if (data.reply && (user.id !== data.reply.userId) && !mentionedUsers.some(u => u.id === data.reply!.userId)) {
-		mentionedUsers.push(await Users.findOne(data.reply.userId).then(ensure));
+		mentionedUsers.push(await Users.findOne({ id: data.reply.userId }).then(ensure));
 	}
 
 	if (data.visibility == 'specified') {
@@ -183,7 +183,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 		}
 
 		if (data.reply && !data.visibleUsers.some(x => x.id === data.reply!.userId)) {
-			data.visibleUsers.push(await Users.findOne(data.reply.userId).then(ensure));
+			data.visibleUsers.push(await Users.findOne({ id: data.reply.userId }).then(ensure));
 		}
 	}
 
@@ -248,7 +248,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 
 		await createMentionedEvents(mentionedUsers, note, nm);
 
-		const profile = await UserProfiles.findOne(user.id).then(ensure);
+		const profile = await UserProfiles.findOne({ userId: user.id }).then(ensure);
 
 		// If has in reply to note
 		if (data.reply) {
@@ -307,13 +307,13 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 
 				// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
 				if (data.reply && data.reply.userHost !== null) {
-					const u = await Users.findOne(data.reply.userId);
+					const u = await Users.findOne({ id: data.reply.userId });
 					if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
 				}
 
 				// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
 				if (data.renote && data.renote.userHost !== null) {
-					const u = await Users.findOne(data.renote.userId);
+					const u = await Users.findOne({ id: data.renote.userId });
 					if (u && Users.isRemoteUser(u)) dm.addDirectRecipe(u);
 				}
 

--- a/src/services/note/polls/update.ts
+++ b/src/services/note/polls/update.ts
@@ -7,12 +7,12 @@ import { deliverToFollowers } from '../../../remote/activitypub/deliver-manager'
 import { deliverToRelays } from '../../relay';
 
 export async function deliverQuestionUpdate(noteId: Note['id']) {
-	const note = await Notes.findOne(noteId);
+	const note = await Notes.findOne({ id: noteId });
 	if (note == null) throw new Error('note not found');
 
 	if (note.localOnly) return;
 
-	const user = await Users.findOne(note.userId);
+	const user = await Users.findOne({ id: note.userId });
 	if (user == null) throw new Error('note not found');
 
 	if (Users.isLocalUser(user)) {

--- a/src/services/note/polls/vote.ts
+++ b/src/services/note/polls/vote.ts
@@ -8,7 +8,7 @@ import { genId } from '../../../misc/gen-id';
 import { createNotification } from '../../create-notification';
 
 export default async function(user: User, note: Note, choice: number) {
-	const poll = await Polls.findOne(note.id);
+	const poll = await Polls.findOne({ noteId: note.id });
 
 	if (poll == null) throw new Error('poll not found');
 
@@ -67,7 +67,7 @@ export default async function(user: User, note: Note, choice: number) {
 		}
 	});
 
-	const profile = await UserProfiles.findOne(user.id);
+	const profile = await UserProfiles.findOne({ userId: user.id });
 
 	// ローカルユーザーが投票した場合この投稿をWatchする
 	if (Users.isLocalUser(user) && profile!.autoWatch) {

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -109,7 +109,7 @@ export default async (user: User, note: Note, reaction?: string) => {
 		}
 	});
 
-	const profile = await UserProfiles.findOne(user.id);
+	const profile = await UserProfiles.findOne({ userId: user.id });
 
 	// ユーザーがローカルユーザーかつ自動ウォッチ設定がオンならばこの投稿をWatchする
 	if (Users.isLocalUser(user) && profile!.autoWatch) {
@@ -121,7 +121,7 @@ export default async (user: User, note: Note, reaction?: string) => {
 		const content = renderActivity(await renderLike(inserted, note));
 		const dm = new DeliverManager(user, content);
 		if (note.userHost !== null) {
-			const reactee = await Users.findOne(note.userId);
+			const reactee = await Users.findOne({ id: note.userId });
 			dm.addDirectRecipe(reactee as IRemoteUser);
 		}
 		dm.addFollowersRecipe();

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -44,7 +44,7 @@ export default async (user: User, note: Note) => {
 		const content = renderActivity(renderUndo(await renderLike(exist, note), user));
 		const dm = new DeliverManager(user, content);
 		if (note.userHost !== null) {
-			const reactee = await Users.findOne(note.userId);
+			const reactee = await Users.findOne({ id: note.userId });
 			dm.addDirectRecipe(reactee as IRemoteUser);
 		}
 		dm.addFollowersRecipe();

--- a/src/services/note/unread.ts
+++ b/src/services/note/unread.ts
@@ -25,7 +25,7 @@ export default async function(user: User, note: Note, isSpecified = false) {
 
 	// 2秒経っても既読にならなかったら「未読の投稿がありますよ」イベントを発行する
 	setTimeout(async () => {
-		const exist = await NoteUnreads.findOne(unread.id);
+		const exist = await NoteUnreads.findOne({ id: unread.id });
 		if (exist == null) return;
 
 		publishMainStream(user.id, 'unreadMention', note.id);


### PR DESCRIPTION
## Summary
Related: #2523
Validationされてるから問題ないはずだけど、ねんのため`findOne(id)`は使わないようにする。
そのうちTypeORM 0.30.0 以降にする。

メモ
だいたいパターン置換でいい
Polls, UserProfiles, UserKeypair, UserPublickeys のプライマリキー名はidではない
findOne(query)とかは置換しないように