### PR TITLE
Only allow exact id matche (Strict AP object id check)

### DIFF
--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -88,7 +88,10 @@ export async function apGet(url: string, user?: ILocalUser) {
 
 	if (res.body.length > 65536) throw new Error('too large JSON');
 
-	return await JSON.parse(res.body);
+	return {
+		object: await JSON.parse(res.body),
+		res,
+	};
 }
 
 function validateContentType(contentType: string | null | undefined): boolean {


### PR DESCRIPTION
## Summary
Strict AP object id check
The id property of the retrieved object must match the final redirect URL actually attempted.

v10 https://github.com/mei23/misskey/pull/4849